### PR TITLE
add FireFox compatibility

### DIFF
--- a/src/dancefloor.js
+++ b/src/dancefloor.js
@@ -15,17 +15,34 @@ export default class Dancefloor extends React.Component {
             }, 100); // css transition delay
             let dx = 0;
             let dy = 0;
-            switch (evt.keyIdentifier.toLowerCase()) {
-                case 'up':
-                    dy += 10; break;
-                case 'down':
-                    dy -= 10; break;
-                case 'left':
-                    dx -= 10; break;
-                case 'right':
-                    dx += 10; break;
-                default:
-                    break;
+            if (evt.keyIdentifier !== undefined) {
+                // Chrome and ...?
+                switch (evt.keyIdentifier.toLowerCase()) {
+                    case 'up':
+                        dy += 10; break;
+                    case 'down':
+                        dy -= 10; break;
+                    case 'left':
+                        dx -= 10; break;
+                    case 'right':
+                        dx += 10; break;
+                    default:
+                        break;
+               }
+            } else if (evt.key !== undefined) {
+                // play nicely with Firefox
+                switch (evt.key.toLowerCase()) {
+                    case 'arrowup':
+                        dy += 10; break;
+                    case 'arrowdown':
+                        dy -= 10; break;
+                    case 'arrowleft':
+                        dx -= 10; break;
+                    case 'arrowright':
+                        dx += 10; break;
+                    default:
+                        break;
+                }
             }
             this.props.move({ dx, dy });
         });

--- a/src/dancefloor.js
+++ b/src/dancefloor.js
@@ -15,31 +15,21 @@ export default class Dancefloor extends React.Component {
             }, 100); // css transition delay
             let dx = 0;
             let dy = 0;
-            if (evt.keyIdentifier !== undefined) {
-                // Chrome and ...?
-                switch (evt.keyIdentifier.toLowerCase()) {
-                    case 'up':
-                        dy += 10; break;
-                    case 'down':
-                        dy -= 10; break;
-                    case 'left':
-                        dx -= 10; break;
-                    case 'right':
-                        dx += 10; break;
-                    default:
-                        break;
-               }
-            } else if (evt.key !== undefined) {
-                // play nicely with Firefox
-                switch (evt.key.toLowerCase()) {
-                    case 'arrowup':
-                        dy += 10; break;
-                    case 'arrowdown':
-                        dy -= 10; break;
-                    case 'arrowleft':
-                        dx -= 10; break;
-                    case 'arrowright':
-                        dx += 10; break;
+            let key = evt.key || evt.keyIdentifier || evt.keyCode.toString();
+            switch (key.toLowerCase()) {
+                // 37 <, 38 ^, 39 v, 40 >
+                case '37':
+                case 'left':
+                    dx -= 10; break;
+                case '38':
+                case 'up':
+                    dy += 10; break;
+                case '39':
+                case 'down':
+                    dy -= 10; break;
+                case '40':
+                case 'right':
+                    dx += 10; break;
                     default:
                         break;
                 }


### PR DESCRIPTION
# Problem:

In the original repo, I could not square-dance using my FireFox browser.  FireFox would throw an error that said: `TypeError: evt.keyIdentifier is undefined`  This forced me square-dance with Chrome.  While Chrome is great and all, I really _really_ wanted to square-dance with FireFox.
# Solution:

Test whether or not `evt.keyIdentifier` is defined.  If not, fall back to `evt.key` instead
